### PR TITLE
Bugfix: Fixed issues with machineClass finalizers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 )
 
 replace (
-	github.com/gardener/machine-controller-manager => github.com/gardener/machine-controller-manager v0.34.0
+	github.com/gardener/machine-controller-manager => github.com/gardener/machine-controller-manager v0.34.3
 	github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.2
 	k8s.io/api => k8s.io/api v0.16.8 // v0.16.8
 	k8s.io/apimachinery => k8s.io/apimachinery v0.16.8 // v0.16.8

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/gardener/machine-controller-manager v0.34.0 h1:PLKWz/wtlapVmgUWD3KpbY8KCs1v0JiK3h4/Bx3f0Rc=
-github.com/gardener/machine-controller-manager v0.34.0/go.mod h1:jxxE+mGgXwg4iPlCHTG4GtUfK2CcHA6yYoIIowoxOZU=
+github.com/gardener/machine-controller-manager v0.34.3 h1:Ffrb5O7MEEDoBrSsmFFtApd7QAKKaTgXlx0LhwYrRlU=
+github.com/gardener/machine-controller-manager v0.34.3/go.mod h1:jxxE+mGgXwg4iPlCHTG4GtUfK2CcHA6yYoIIowoxOZU=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-ini/ini v1.36.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=

--- a/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/types.go
+++ b/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/types.go
@@ -222,6 +222,9 @@ const (
 
 	// MachineFailed means operation failed leading to machine status failure
 	MachineFailed MachinePhase = "Failed"
+
+	// MachineCrashLoopBackOff means creation or deletion of the machine is failing.
+	MachineCrashLoopBackOff MachinePhase = "CrashLoopBackOff"
 )
 
 // MachinePhase is a label for the condition of a machines at the current time.

--- a/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/machine_types.go
+++ b/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/machine_types.go
@@ -146,9 +146,12 @@ const (
 
 	// MachineFailed means operation failed leading to machine status failure
 	MachineFailed MachinePhase = "Failed"
+
+	// MachineCrashLoopBackOff means creation or deletion of the machine is failing.
+	MachineCrashLoopBackOff MachinePhase = "CrashLoopBackOff"
 )
 
-// MachinePhase is a label for the condition of a machines at the current time.
+// MachineState is a current state of the machine.
 type MachineState string
 
 // These are the valid statuses of machines.

--- a/vendor/github.com/gardener/machine-controller-manager/pkg/util/provider/machinecontroller/controller.go
+++ b/vendor/github.com/gardener/machine-controller-manager/pkg/util/provider/machinecontroller/controller.go
@@ -136,13 +136,17 @@ func NewController(
 		DeleteFunc: controller.machineClassToSecretDelete,
 	})
 
+	// Machine Class Controller Informers
 	machineInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    controller.machineToMachineClassAdd,
+		UpdateFunc: controller.machineToMachineClassUpdate,
 		DeleteFunc: controller.machineToMachineClassDelete,
 	})
 
 	machineClassInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.machineClassAdd,
 		UpdateFunc: controller.machineClassUpdate,
+		DeleteFunc: controller.machineClassDelete,
 	})
 
 	// Machine Controller Informers

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ github.com/beorn7/perks/quantile
 github.com/davecgh/go-spew/spew
 # github.com/evanphx/json-patch v4.2.0+incompatible
 github.com/evanphx/json-patch
-# github.com/gardener/machine-controller-manager v0.30.0 => github.com/gardener/machine-controller-manager v0.34.0
+# github.com/gardener/machine-controller-manager v0.30.0 => github.com/gardener/machine-controller-manager v0.34.3
 github.com/gardener/machine-controller-manager/pkg/apis/machine
 github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1
 github.com/gardener/machine-controller-manager/pkg/apis/machine/validation


### PR DESCRIPTION
- Added a more comprehensive set of events to trigger machine class reconciliations.
- Finalizers are added by default for all machine class objects.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Added a more comprehensive set of events to trigger machine class reconciliations.
```
```improvement operator
Finalizers are added by default for all machine class objects.
```
