### PR TITLE
Support Gardener credentials data keys

### DIFF
--- a/kubernetes/secret.yaml
+++ b/kubernetes/secret.yaml
@@ -8,4 +8,6 @@ metadata:
 data:
   userData: "encoded-cloud-config" # GCP cloud config file (base64 encoded)
   serviceAccountJSON: "{...}" # GCP service account json object (base64 encoded)
+### Alternative data keys are:
+# serviceaccount.json: "{...}" # GCP service account json object (base64 encoded)
 type: Opaque

--- a/pkg/gcp/apis/provider_spec.go
+++ b/pkg/gcp/apis/provider_spec.go
@@ -17,6 +17,10 @@ package api
 const (
 	// GCPServiceAccountJSON is a constant for a key name that is part of the GCP cloud credentials.
 	GCPServiceAccountJSON = "serviceAccountJSON"
+	// GCPAlternativeServiceAccountJSON is a constant for a key name of a secret containing the GCP credentials (service
+	// account json).
+	GCPAlternativeServiceAccountJSON = "serviceaccount.json"
+
 	// APIVersionV1alpha1 is the API version for MCM
 	APIVersionV1alpha1 = "mcm.gardener.cloud/v1alpha1"
 )

--- a/pkg/gcp/apis/validation/validation.go
+++ b/pkg/gcp/apis/validation/validation.go
@@ -36,16 +36,17 @@ func validateSecrets(secret *corev1.Secret) []error {
 	var allErrs []error
 
 	if secret == nil {
-		allErrs = append(allErrs, fmt.Errorf("Secret object that has been passed by the MCM is nil"))
+		allErrs = append(allErrs, fmt.Errorf("secret object that has been passed by the MCM is nil"))
 	} else {
-		_, serviceAccountJSONExists := secret.Data["serviceAccountJSON"]
+		_, serviceAccountJSONExists := secret.Data[api.GCPServiceAccountJSON]
+		_, serviceAccountJSONAlternativeExists := secret.Data[api.GCPAlternativeServiceAccountJSON]
 		_, userDataExists := secret.Data["userData"]
 
-		if !serviceAccountJSONExists {
-			allErrs = append(allErrs, fmt.Errorf("Secret serviceAccountJSON is required field"))
+		if !serviceAccountJSONExists && !serviceAccountJSONAlternativeExists {
+			allErrs = append(allErrs, fmt.Errorf("secret %s or %s is required field", api.GCPServiceAccountJSON, api.GCPAlternativeServiceAccountJSON))
 		}
 		if !userDataExists {
-			allErrs = append(allErrs, fmt.Errorf("Secret userData is required field"))
+			allErrs = append(allErrs, fmt.Errorf("secret userData is required field"))
 		}
 	}
 

--- a/pkg/gcp/fake/mockclient.go
+++ b/pkg/gcp/fake/mockclient.go
@@ -25,22 +25,26 @@ import (
 	compute "google.golang.org/api/compute/v1"
 	option "google.golang.org/api/option"
 	corev1 "k8s.io/api/core/v1"
+
+	api "github.com/gardener/machine-controller-manager-provider-gcp/pkg/gcp/apis"
 )
 
-//PluginSPIImpl is the mock implementation of PluginSPIImpl
+// PluginSPIImpl is the mock implementation of PluginSPIImpl
 type PluginSPIImpl struct {
 	Client *http.Client
 }
 
-//NewComputeService creates a compute service instance using the mock
+// NewComputeService creates a compute service instance using the mock
 func (ms *PluginSPIImpl) NewComputeService(secrets *corev1.Secret) (context.Context, *compute.Service, error) {
 	ctx := context.Background()
 
-	if _, exists := secrets.Data["serviceAccountJSON"]; !exists {
+	_, serviceAccountJSON := secrets.Data[api.GCPServiceAccountJSON]
+	_, serviceAccountJSONAlternative := secrets.Data[api.GCPAlternativeServiceAccountJSON]
+	if !serviceAccountJSON && !serviceAccountJSONAlternative {
 		return nil, nil, fmt.Errorf("Missing secrets to connect to compute service")
 	}
 
-	//create a compute service using a mockclient work
+	// create a compute service using a mockclient work
 	client := option.WithHTTPClient(ms.Client)
 	endpoint := option.WithEndpoint("http://127.0.0.1:6666")
 

--- a/pkg/gcp/machine_controller_test.go
+++ b/pkg/gcp/machine_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"net/http"
 
+	api "github.com/gardener/machine-controller-manager-provider-gcp/pkg/gcp/apis"
 	fake "github.com/gardener/machine-controller-manager-provider-gcp/pkg/gcp/fake"
 	v1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
@@ -48,9 +49,9 @@ const (
 	// ListFailAtJSONUnmarshalling is the error message returned when an malformed JSON is sent to the plugin by the caller
 	ListFailAtJSONUnmarshalling string = "machine codes error: code = [Internal] message = [List machines failed on decodeProviderSpecAndSecret: machine codes error: code = [Internal] message = [unexpected end of JSON input]]"
 	// FailAtNoSecretsPassed is the error message returned when no secrets are passed to the the plugin by the caller
-	FailAtNoSecretsPassed string = "machine codes error: code = [Internal] message = [Create machine \"dummy-machine\" failed on decodeProviderSpecAndSecret: machine codes error: code = [Internal] message = [Error while validating ProviderSpec [Secret serviceAccountJSON is required field Secret userData is required field]]]"
+	FailAtNoSecretsPassed string = "machine codes error: code = [Internal] message = [Create machine \"dummy-machine\" failed on decodeProviderSpecAndSecret: machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret serviceAccountJSON or serviceaccount.json is required field secret userData is required field]]]"
 	// FailAtSecretsWithNoUserData is the error message returned when secrets map has no userdata provided by the caller
-	FailAtSecretsWithNoUserData string = "machine codes error: code = [Internal] message = [Create machine \"dummy-machine\" failed on decodeProviderSpecAndSecret: machine codes error: code = [Internal] message = [Error while validating ProviderSpec [Secret userData is required field]]]"
+	FailAtSecretsWithNoUserData string = "machine codes error: code = [Internal] message = [Create machine \"dummy-machine\" failed on decodeProviderSpecAndSecret: machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret userData is required field]]]"
 	// FailAtInvalidProjectID is the error returned when an invalid project id value is provided by the caller
 	FailAtInvalidProjectID string = "machine codes error: code = [Internal] message = [Create machine \"dummy-machine\" failed: json: cannot unmarshal number into Go struct field .project_id of type string]"
 	// FailAtInvalidZonePostCall is the  error returned when a post call should fail with an invalid zone is sent in the POST call -- this is used to simulate server error
@@ -114,17 +115,17 @@ var _ = Describe("#MachineController", func() {
 	}
 
 	gcpProviderSecret := map[string][]byte{
-		"userData":           []byte("dummy-data"),
-		"serviceAccountJSON": []byte("{\"type\":\"service_account\",\"project_id\":\"sap-se-gcp-scp-k8s-dev\"}"),
+		"userData":                []byte("dummy-data"),
+		api.GCPServiceAccountJSON: []byte("{\"type\":\"service_account\",\"project_id\":\"sap-se-gcp-scp-k8s-dev\"}"),
 	}
 
 	gcpProviderSecretWithMisssingUserData := map[string][]byte{
 		//"userData":           []byte(""),
-		"serviceAccountJSON": []byte("{\"type\":\"service_account\",\"project_id\":\"sap-se-gcp-scp-k8s-dev\"}"),
+		api.GCPServiceAccountJSON: []byte("{\"type\":\"service_account\",\"project_id\":\"sap-se-gcp-scp-k8s-dev\"}"),
 	}
 	gcpProviderSecretWithoutProjectID := map[string][]byte{
-		"userData":           []byte("dummy-data"),
-		"serviceAccountJSON": []byte("{\"type\":\"service_account\",\"project_id\":10}"),
+		"userData":                []byte("dummy-data"),
+		api.GCPServiceAccountJSON: []byte("{\"type\":\"service_account\",\"project_id\":10}"),
 	}
 
 	var ms *MachinePlugin


### PR DESCRIPTION
/area open-source usability
/kind enhancement
/priority normal
/platform gcp

**What this PR does / why we need it**:
All the secret keys used by Gardener are now also allowed as alternatives for this machine-controller-manager plugin. This helps to not make mappings for the data keys.

**Special notes for your reviewer**:
ℹ️ Similar improvement for in-tree driver: https://github.com/gardener/machine-controller-manager/pull/578/commits/0e41070979b21dae4e27fe6504bdc99f651ec3b7 (https://github.com/gardener/machine-controller-manager/pull/578)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```feature operator
The machine class secret does now also accept the data key `serviceaccount.json` as alternatives for today's key.
```