### PR TITLE
go version in pipeline upgraded to v1.16.6

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -19,12 +19,12 @@ machine-controller-manager-provider-gcp:
             image: 'eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-gcp'
     steps:
       check:
-        image: 'golang:1.13.3'
+        image: 'golang:1.16.6'
       build:
-        image: 'golang:1.13.3'
+        image: 'golang:1.16.6'
         output_dir: 'binary'
       test:
-        image: 'golang:1.13.3'
+        image: 'golang:1.16.6'
   jobs:
     head-update:
       traits:


### PR DESCRIPTION
**What this PR does / why we need it**:
Pipeline steps will use go version 1.16.6
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
NONE
```