### PR TITLE
Updates test step image in pipeline_definition

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -24,7 +24,7 @@ machine-controller-manager-provider-gcp:
         image: 'golang:1.16.6'
         output_dir: 'binary'
       test:
-        image: 'golang:1.16.6'
+        image: 'eu.gcr.io/gardener-project/gardener/testmachinery/base-step:stable'
   jobs:
     head-update:
       traits:


### PR DESCRIPTION
**What this PR does / why we need it**:
Test step image updated to use `test-machinery/base-step:stable` which consists of `cc/utils/cli.py` which can be used to access the kubeconfigs 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
NONE
```