### PR TITLE
Component descriptor added

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [ -z "${MAIN_REPO_DIR:-}" ]; then
+  export MAIN_REPO_DIR="$(readlink -f "$(dirname "${0}")/..")"
+fi
+MCM_VERSION_FILEPATH="${MAIN_REPO_DIR}/MCM_VERSION"
+
+export VERSION="$(cat "${MCM_VERSION_FILEPATH}")"
+
+${ADD_DEPENDENCIES_CMD} \
+  --component-dependencies "{\"name\":\"github.com/gardener/machine-controller-manager\",\"version\":\"$VERSION\"}"
+
+mv "${BASE_DEFINITION_PATH}" "${COMPONENT_DESCRIPTOR_PATH}"


### PR DESCRIPTION
**What this PR does / why we need it**:
MCM as a dependency added in component descriptor , this will help CI pipeline job to look for version of MCM and create a PR for revendoring if needed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
NONE
```