### PR TITLE
Adds GPU support 

### DIFF
--- a/pkg/api/v1alpha1/provider_spec.go
+++ b/pkg/api/v1alpha1/provider_spec.go
@@ -51,6 +51,10 @@ type GCPProviderSpec struct {
 	// must be created before you can assign them.
 	Disks []*GCPDisk `json:"disks,omitempty"`
 
+	// GPUConfig: Configurations related to GPU which would be attached to the instance. Enough
+	// Quota of the particular GPU should be available.
+	GPUConfig *GPUConfig `json:"gpuConfig,omitempty"`
+
 	// Labels: Labels to apply to this instance.
 	Labels map[string]string `json:"labels,omitempty"`
 
@@ -283,4 +287,9 @@ type GCPServiceAccount struct {
 	// Scopes: The list of scopes to be made available for this service
 	// account.
 	Scopes []string `json:"scopes"`
+}
+
+type GPUConfig struct {
+	AcceleratorType string `json:"acceleratorType"`
+	CountPerNode    int64  `json:"countPerNode"`
 }

--- a/pkg/api/v1alpha1/provider_spec.go
+++ b/pkg/api/v1alpha1/provider_spec.go
@@ -51,9 +51,9 @@ type GCPProviderSpec struct {
 	// must be created before you can assign them.
 	Disks []*GCPDisk `json:"disks,omitempty"`
 
-	// GPUConfig: Configurations related to GPU which would be attached to the instance. Enough
+	// Gpu: Configurations related to GPU which would be attached to the instance. Enough
 	// Quota of the particular GPU should be available.
-	GPUConfig *GPUConfig `json:"gpuConfig,omitempty"`
+	Gpu *GCPGpu `json:"gpuConfig,omitempty"`
 
 	// Labels: Labels to apply to this instance.
 	Labels map[string]string `json:"labels,omitempty"`
@@ -289,7 +289,8 @@ type GCPServiceAccount struct {
 	Scopes []string `json:"scopes"`
 }
 
-type GPUConfig struct {
+// GCPGpu describes gpu configurations for GCP
+type GCPGpu struct {
 	AcceleratorType string `json:"acceleratorType"`
-	CountPerNode    int64  `json:"countPerNode"`
+	Count           int64  `json:"count"`
 }

--- a/pkg/api/v1alpha1/provider_spec.go
+++ b/pkg/api/v1alpha1/provider_spec.go
@@ -53,7 +53,7 @@ type GCPProviderSpec struct {
 
 	// Gpu: Configurations related to GPU which would be attached to the instance. Enough
 	// Quota of the particular GPU should be available.
-	Gpu *GCPGpu `json:"gpuConfig,omitempty"`
+	Gpu *GCPGpu `json:"gpu,omitempty"`
 
 	// Labels: Labels to apply to this instance.
 	Labels map[string]string `json:"labels,omitempty"`

--- a/pkg/gcp/machine_controller_util.go
+++ b/pkg/gcp/machine_controller_util.go
@@ -81,6 +81,17 @@ func (ms *MachinePlugin) CreateMachineUtil(ctx context.Context, machineName stri
 		}
 	)
 
+	if providerSpec.GPUConfig != nil {
+		instance.GuestAccelerators = []*compute.AcceleratorConfig{
+			{
+				AcceleratorType:  fmt.Sprintf("projects/%s/zones/%s/acceleratorTypes/%s", project, zone, providerSpec.GPUConfig.AcceleratorType),
+				AcceleratorCount: providerSpec.GPUConfig.CountPerNode,
+			},
+		}
+		// need to make onHostMaintainence as `TERMINATE` as live-migration not supported for VMs with GPU attached
+		instance.Scheduling.OnHostMaintenance = "TERMINATE"
+	}
+
 	if providerSpec.Description != nil {
 		instance.Description = *providerSpec.Description
 	}

--- a/pkg/gcp/machine_controller_util.go
+++ b/pkg/gcp/machine_controller_util.go
@@ -81,15 +81,13 @@ func (ms *MachinePlugin) CreateMachineUtil(ctx context.Context, machineName stri
 		}
 	)
 
-	if providerSpec.GPUConfig != nil {
+	if providerSpec.Gpu != nil {
 		instance.GuestAccelerators = []*compute.AcceleratorConfig{
 			{
-				AcceleratorType:  fmt.Sprintf("projects/%s/zones/%s/acceleratorTypes/%s", project, zone, providerSpec.GPUConfig.AcceleratorType),
-				AcceleratorCount: providerSpec.GPUConfig.CountPerNode,
+				AcceleratorType:  fmt.Sprintf("projects/%s/zones/%s/acceleratorTypes/%s", project, zone, providerSpec.Gpu.AcceleratorType),
+				AcceleratorCount: providerSpec.Gpu.Count,
 			},
 		}
-		// need to make onHostMaintainence as `TERMINATE` as live-migration not supported for VMs with GPU attached
-		instance.Scheduling.OnHostMaintenance = "TERMINATE"
 	}
 
 	if providerSpec.Description != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fields regarding GPU have been introduced in the providerConfig.
These expose two fields:
1. acceleratorType
2. count

`live-migration` for VM is not allowed for VM with GPU attached, so `onHostMigration=TERMINATE` needs to be configured if using MCM directly

**Which issue(s) this PR fixes**:
Fixes #
a part of https://github.com/gardener/gardener-extension-provider-gcp/issues/132
**Special notes for your reviewer**:
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```noteworthy user
VM with GPU attached can now be created on GCP. Note for a2 series machine , no need to specify `acceleratorType` and `count` as it already comes with inbuilt GPU.
```