### PR TITLE
Automated cherry pick of #43: Update base/build images

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -17,9 +17,9 @@ machine-controller-manager-provider-gcp:
     steps_template: &steps_anchor
       steps:
         check:
-          image: 'golang:1.17.5'
+          image: 'golang:1.17.9'
         build:
-          image: 'golang:1.17.5'
+          image: 'golang:1.17.9'
           output_dir: 'binary'
         test:
           image: 'eu.gcr.io/gardener-project/gardener/testmachinery/base-step:stable'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder                                  #############
-FROM eu.gcr.io/gardener-project/3rd/golang:1.17.5 AS builder
+FROM golang:1.17.9 AS builder
 
 WORKDIR /go/src/github.com/gardener/machine-controller-manager-provider-gcp
 COPY . .
@@ -7,7 +7,7 @@ COPY . .
 RUN .ci/build
 
 #############      base                                     #############
-FROM eu.gcr.io/gardener-project/3rd/alpine:3.15.0 as base
+FROM alpine:3.15.4 as base
 
 RUN apk add --update bash curl tzdata
 WORKDIR /


### PR DESCRIPTION
Cherry pick of #43 on rel-v0.9.

#43: Update base/build images

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Base image updated to alpine `v3.15.4` and build image to golang `1.17.9`.
```