### PR TITLE
Better error message on ServiceAccountJSON decode failure

### DIFF
--- a/pkg/gcp/plugin.go
+++ b/pkg/gcp/plugin.go
@@ -23,6 +23,7 @@ package gcp
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"golang.org/x/oauth2/google"
@@ -57,7 +58,7 @@ func (spi *PluginSPIImpl) NewComputeService(secret *corev1.Secret) (context.Cont
 
 	jwt, err := google.JWTConfigFromJSON([]byte(serviceAccountJSON), compute.CloudPlatformScope)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("cannot parse serviceAccountJSON secret value: %w", err)
 	}
 
 	clientOption := option.WithTokenSource(jwt.TokenSource(ctx))


### PR DESCRIPTION
**What this PR does / why we need it**:
I spent more than an hour trying to troubleshoot `invalid character '\n' in string literal` when creating new VMs, At the end it was extra `\n` in the secret value

Thought it's better to guide the developer to the root cause of the error by enhancing the error message

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement developer
Enhance error message when decoding serviceAccountJSON fails.
```
