### PR TITLE
Add support for min cpu platform

### DIFF
--- a/kubernetes/machine-class.yaml
+++ b/kubernetes/machine-class.yaml
@@ -25,6 +25,7 @@ providerSpec:
   metadata: # Metadata key-value pairs
     - key: ash
       value: my-value
+# minCpuPlatform: Intel Skylake # minimum CPU platform to request for the instance (optional).
   networkInterfaces:
     - network: network-name # Network name to attach the instance to
       subnetwork: sub-net-name # Subnet name to attach the instance to

--- a/pkg/api/v1alpha1/provider_spec.go
+++ b/pkg/api/v1alpha1/provider_spec.go
@@ -86,6 +86,10 @@ type GCPProviderSpec struct {
 	// This includes custom metadata and predefined keys.
 	Metadata []*GCPMetadata `json:"metadata,omitempty"`
 
+	// MinCpuPlatform: The name of the minimum CPU platform that is requested
+	// for this instance.
+	MinCPUPlatform string `json:"minCpuPlatform,omitempty"`
+
 	// NetworkInterfaces: An array of network configurations for this
 	// instance. These specify how interfaces are configured to interact
 	// with other network services, such as connecting to the internet.

--- a/pkg/gcp/machine_controller_util.go
+++ b/pkg/gcp/machine_controller_util.go
@@ -70,6 +70,7 @@ func (ms *MachinePlugin) CreateMachineUtil(ctx context.Context, machineName stri
 			DeletionProtection: providerSpec.DeletionProtection,
 			Labels:             providerSpec.Labels,
 			MachineType:        fmt.Sprintf("zones/%s/machineTypes/%s", zone, providerSpec.MachineType),
+			MinCpuPlatform:     providerSpec.MinCPUPlatform,
 			Name:               machineName,
 			Scheduling: &compute.Scheduling{
 				AutomaticRestart:  &providerSpec.Scheduling.AutomaticRestart,


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for setting the minimum CPU platform when creating VMs.

**Which issue(s) this PR fixes**:
`-`

**Special notes for your reviewer**:
`-`

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```noteworthy developer
The GCPProviderSpec now supports setting `minCpuPlatform` to configure the minimum CPU platform requested for the VM.
```