### PR TITLE
Update testmachinery image location

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -31,7 +31,7 @@ machine-controller-manager-provider-gcp:
           image: 'golang:1.21.4'
           output_dir: 'binary'
         test:
-          image: 'eu.gcr.io/gardener-project/gardener/testmachinery/base-step:stable'
+          image: 'europe-docker.pkg.dev/gardener-project/releases/testmachinery/base-step:stable'
     version_template: &version_anchor
       version:
         inject_effective_version: true


### PR DESCRIPTION
**What this PR does / why we need it**:
With https://github.com/gardener/test-infra/pull/479, testmachinery images are published to a new location.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
NONE
```