### PR TITLE
switch GCR -> Artifact-Registry 

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,26 +1,11 @@
 machine-controller-manager-provider-gcp:
   base_definition:
-    repo: ~
+    traits:
+      version:
+        inject_effective_version: true
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
   inherit:
-    publish_template: &publish_anchor
-      publish:
-        dockerimages:
-          machine-controller-manager-provider-gcp:
-            inputs:
-              repos:
-                source: ~ # default
-              steps:
-                build: ~
-            image: 'eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-gcp'
-            resource_labels:
-            - name: 'gardener.cloud/cve-categorisation'
-              value:
-                network_exposure: 'protected'
-                authentication_enforced: false
-                user_interaction: 'gardener-operator'
-                confidentiality_requirement: 'high'
-                integrity_requirement: 'high'
-                availability_requirement: 'low'
     steps_template: &steps_anchor
       steps:
         check:
@@ -30,27 +15,44 @@ machine-controller-manager-provider-gcp:
           output_dir: 'binary'
         test:
           image: 'europe-docker.pkg.dev/gardener-project/releases/testmachinery/base-step:stable'
-    version_template: &version_anchor
-      version:
-        inject_effective_version: true
   jobs:
     head-update:
       <<: *steps_anchor
       traits:
-        <<: *version_anchor
-        component_descriptor: ~
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
         draft_release: ~
-        <<: *publish_anchor
+        publish:
+          dockerimages: &default_images
+            machine-controller-manager-provider-gcp: &mcmpg-image
+              inputs:
+                repos:
+                  source: ~ # default
+                steps:
+                  build: ~
+              image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/machine-controller-manager-provider-gcp
+              resource_labels:
+              - name: 'gardener.cloud/cve-categorisation'
+                value:
+                  network_exposure: 'protected'
+                  authentication_enforced: false
+                  user_interaction: 'gardener-operator'
+                  confidentiality_requirement: 'high'
+                  integrity_requirement: 'high'
+                  availability_requirement: 'low'
     pull-request:
       <<: *steps_anchor
       traits:
-        <<: *version_anchor
         pull-request: ~
-        <<: *publish_anchor
+        publish:
+          dockerimages:
+            <<: *default_images
     create-upgrade-prs:
       traits:
-        component_descriptor: ~
-        version: ~
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
         cronjob:
           interval: '24h'
         update_component_deps:
@@ -59,15 +61,21 @@ machine-controller-manager-provider-gcp:
     release:
       <<: *steps_anchor
       traits:
-        <<: *publish_anchor
         version:
           preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         release:
           nextversion: 'bump_minor'
+        publish:
+          dockerimages:
+            <<: *default_images
+            machine-controller-manager-provider-gcp:
+              <<: *mcmpg-image
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager-provider-gcp
         slack:
           default_channel: 'internal_scp_workspace'
           channel_cfgs:
             internal_scp_workspace:
               channel_name: 'C0170QTBJUW' # gardener-mcm
               slack_cfg_name: 'scp_workspace'
-        component_descriptor: ~

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,5 +1,4 @@
 machine-controller-manager-provider-gcp:
-  template: 'default'
   base_definition:
     repo: ~
   inherit:
@@ -12,7 +11,6 @@ machine-controller-manager-provider-gcp:
                 source: ~ # default
               steps:
                 build: ~
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-gcp'
             resource_labels:
             - name: 'gardener.cloud/cve-categorisation'

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 PROVIDER_NAME       := Gcp
 PROJECT_NAME        := gardener
 BINARY_PATH         := bin/
-IMAGE_REPOSITORY    := eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-gcp
+IMAGE_REPOSITORY    := europe-docker.pkg.dev/gardener-project/public/gardener/machine-controller-manager-provider-gcp
 IMAGE_TAG           := $(shell cat VERSION)
 MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME := machine-controller-manager
 TAGS_ARE_STRINGS := true

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: machine-controller-manager
-        image: eu.gcr.io/gardener-project/gardener/machine-controller-manager:v0.39.0
+        image: europe-docker.pkg.dev/gardener-project/public/gardener/machine-controller-manager:v0.39.0
         imagePullPolicy: Always
         command:
           - ./machine-controller-manager
@@ -57,7 +57,7 @@ spec:
         - --machine-safety-orphan-vms-period=30m # Optional Parameter - Default value 30mins - Time period (in time) used to poll for orphan VMs by safety controller.
         - --node-conditions=ReadonlyFilesystem,KernelDeadlock,DiskPressure # List of comma-separated/case-sensitive node-conditions which when set to True will change machine to a failed state after MachineHealthTimeout duration. It may further be replaced with a new machine if the machine is backed by a machine-set object.
         - --v=3
-        image: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-gcp:v0.7.0
+        image: europe-docker.pkg.dev/gardener-project/public/gardener/machine-controller-manager-provider-gcp:v0.7.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
