### PR TITLE
remove disk type validation

### DIFF
--- a/pkg/gcp/validation/validation.go
+++ b/pkg/gcp/validation/validation.go
@@ -27,15 +27,8 @@ import (
 )
 
 const (
-	// DiskTypeStandard is the standard disk type
-	DiskTypeStandard = "pd-standard"
-	// DiskTypeSSD is the SSD disk type
-	DiskTypeSSD = "pd-ssd"
 	// DiskTypeScratch is the SCRATCH disk type
 	DiskTypeScratch = "SCRATCH"
-	// DiskTypePDBalanced is the balanced disk type
-	DiskTypePDBalanced = "pd-balanced"
-
 	// DiskInterfaceNVME is the NVME disk interface
 	DiskInterfaceNVME = "NVME"
 	// DiskInterfaceSCSI is the SCSI disk interface
@@ -104,9 +97,6 @@ func validateGCPDisks(disks []*api.GCPDisk, fldPath *field.Path) []error {
 		idxPath := fldPath.Index(i)
 		if disk.SizeGb < 20 {
 			allErrs = append(allErrs, field.Invalid(idxPath.Child("sizeGb"), disk.SizeGb, "disk size must be at least 20 GB"))
-		}
-		if disk.Type != DiskTypeStandard && disk.Type != DiskTypeSSD && disk.Type != DiskTypeScratch && disk.Type != DiskTypePDBalanced {
-			allErrs = append(allErrs, field.NotSupported(idxPath.Child("type"), disk.Type, []string{DiskTypeStandard, DiskTypeSSD, DiskTypeScratch, DiskTypePDBalanced}))
 		}
 		if disk.Type == DiskTypeScratch && (disk.Interface != DiskInterfaceNVME && disk.Interface != DiskInterfaceSCSI) {
 			allErrs = append(allErrs, field.NotSupported(idxPath.Child("interface"), disk.Interface, []string{DiskInterfaceNVME, DiskInterfaceSCSI}))


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes strict disk type validation. The main reason is to support https://github.com/gardener/gardener-extension-provider-gcp/issues/702. As providers add more disk types the validations need to be adapted. 

The PR could go either way, of adding the check for the new type or removing the current check and I was in favor of the later approach. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
Remove strict validation about disk types
```