### PR TITLE
Replace goling with golangci-lint

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -6,8 +6,22 @@
 
 set -e
 
-source "$(dirname ${0})/setupenv.src"
+if [[ $(uname) == 'Darwin' ]]; then
+  READLINK_BIN="greadlink"
+else
+  READLINK_BIN="readlink"
+fi
 
+if [[ -z "${SOURCE_PATH}" ]]; then
+  export SOURCE_PATH="$(${READLINK_BIN} -f $(dirname ${0})/..)"
+else
+  export SOURCE_PATH="$(${READLINK_BIN} -f "${SOURCE_PATH}")"
+fi
+
+export GOBIN="${SOURCE_PATH}/tmp/bin"
+export PATH="${GOBIN}:${PATH}"
+
+###############################################################################
 # Install golangci-lint (linting tool).
 if [[ -z "${GOLANGCI_LINT_VERSION}" ]]; then
   export GOLANGCI_LINT_VERSION=v1.57.1
@@ -18,6 +32,8 @@ echo "Successfully fetched golangci-lint"
 golangci-lint version
 
 ###############################################################################
+cd ${SOURCE_PATH}
+
 PACKAGES="$(go list -e ./... | grep -vE '/internal/flags')"
 PACKAGES_DIRS="$(echo ${PACKAGES} | sed "s|github.com/gardener/machine-controller-manager-provider-gcp|.|g")"
 
@@ -29,7 +45,7 @@ go vet ${PACKAGES}
 echo "Running gofmt..."
 gofmt -l -w -s ${PACKAGES_DIRS}
 
-echo "Executing golangci-lint"
+echo "Executing golangci-lint..."
 # golangci-lint can't be run from outside the directory
 (cd ${SOURCE_PATH} && golangci-lint run -c .golangci.yaml --timeout 10m)
 

--- a/.ci/check
+++ b/.ci/check
@@ -8,7 +8,14 @@ set -e
 
 source "$(dirname ${0})/setupenv.src"
 
-go install  golang.org/x/lint/golint
+# Install golangci-lint (linting tool).
+if [[ -z "${GOLANGCI_LINT_VERSION}" ]]; then
+  export GOLANGCI_LINT_VERSION=v1.57.1
+fi
+echo "Fetching golangci-lint tool"
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@"${GOLANGCI_LINT_VERSION}"
+echo "Successfully fetched golangci-lint"
+golangci-lint version
 
 ###############################################################################
 PACKAGES="$(go list -e ./... | grep -vE '/internal/flags')"
@@ -22,9 +29,8 @@ go vet ${PACKAGES}
 echo "Running gofmt..."
 gofmt -l -w -s ${PACKAGES_DIRS}
 
-# Execute lint checks.
-echo "Running golint..."
-for package in ${PACKAGES_DIRS}; do
-    golint -set_exit_status $(find $package -maxdepth 1 -name "*.go" | grep -vE 'zz_generated|_test.go')
-done
+echo "Executing golangci-lint"
+# golangci-lint can't be run from outside the directory
+(cd ${SOURCE_PATH} && golangci-lint run -c .golangci.yaml --timeout 10m)
+
 echo "Check script has passed successfully"

--- a/.ci/setupenv.src
+++ b/.ci/setupenv.src
@@ -8,23 +8,6 @@ else
   export BINARY_PATH="$(readlink -f "${BINARY_PATH}")/bin"
 fi
 
-# The `go <cmd>` commands requires to see the target repository to be part of a
-# Go workspace. Thus, if we are not yet in a Go workspace, let's create one
-# temporarily by using symbolic links.
-if [[ "${SOURCE_PATH}" != *"$PATHINWS" || -z "$GOPATH" ]]; then
-  echo "generating local go path..."
-  SOURCE_SYMLINK_PATH="${SOURCE_PATH}/tmp/$PATHINWS"
-  if [[ -d "${SOURCE_PATH}/tmp" ]]; then
-    rm -rf "${SOURCE_PATH}/tmp"
-  fi
-  mkdir -p "$(dirname "${SOURCE_PATH}/tmp/$PATHINWS")"
-  ln -s "${SOURCE_PATH}" "${SOURCE_SYMLINK_PATH}"
-  cd "${SOURCE_SYMLINK_PATH}"
-
-  export GOPATH="${SOURCE_PATH}/tmp"
-  export GOBIN="${SOURCE_PATH}/tmp/bin"
-  export PATH="${GOBIN}:${PATH}"
-else
-  cd "$SOURCE_PATH"
-fi
+export GOBIN="${SOURCE_PATH}/tmp/bin"
+export PATH="${GOBIN}:${PATH}"
 

--- a/.ci/setupenv.src
+++ b/.ci/setupenv.src
@@ -8,6 +8,22 @@ else
   export BINARY_PATH="$(readlink -f "${BINARY_PATH}")/bin"
 fi
 
-export GOBIN="${SOURCE_PATH}/tmp/bin"
-export PATH="${GOBIN}:${PATH}"
+# The `go <cmd>` commands requires to see the target repository to be part of a
+# Go workspace. Thus, if we are not yet in a Go workspace, let's create one
+# temporarily by using symbolic links.
+if [[ "${SOURCE_PATH}" != *"$PATHINWS" || -z "$GOPATH" ]]; then
+  echo "generating local go path..."
+  SOURCE_SYMLINK_PATH="${SOURCE_PATH}/tmp/$PATHINWS"
+  if [[ -d "${SOURCE_PATH}/tmp" ]]; then
+    rm -rf "${SOURCE_PATH}/tmp"
+  fi
+  mkdir -p "$(dirname "${SOURCE_PATH}/tmp/$PATHINWS")"
+  ln -s "${SOURCE_PATH}" "${SOURCE_SYMLINK_PATH}"
+  cd "${SOURCE_SYMLINK_PATH}"
 
+  export GOPATH="${SOURCE_PATH}/tmp"
+  export GOBIN="${SOURCE_PATH}/tmp/bin"
+  export PATH="${GOBIN}:${PATH}"
+else
+  cd "$SOURCE_PATH"
+fi

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,49 @@
+run:
+  concurrency: 4
+  timeout: 10m
+
+linters:
+  disable:
+    - unused
+  enable:
+    - revive
+    - loggercheck
+
+issues:
+  exclude-use-default: false
+  exclude:
+    # errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
+    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked
+    # revive:
+    - var-naming # ((var|const|struct field|func) .* should be .*
+    - dot-imports # should not use dot imports
+    - package-comments # package comment should be of the form
+    - unexported-return # exported func .* returns unexported type .*, which can be annoying to use
+    - indent-error-flow # if block ends with a return statement, so drop this else and outdent its block
+    - "exported: (type|func) name will be used as .* by other packages, and that stutters;"
+    # typecheck:
+    - "undeclared name: `.*`"
+    - "\".*\" imported but not used"
+    # allow non-capitalized messages if they start with technical terms
+    - "structured logging message should be capitalized: \"garden(er-apiserver|er-controller-manager|er-admission-controller|er-operator|er-resource-manager|let)"
+  exclude-rules:
+    - linters:
+        - staticcheck
+      text: "SA1019:" # Excludes messages where deprecated variables are used
+
+  exclude-files:
+    - "zz_generated\\..*\\.go$"
+
+linters-settings:
+  revive:
+    rules:
+      - name: duplicated-imports
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: context-as-argument
+      - name: early-return
+      - name: exported
+  loggercheck:
+    no-printf-like: true
+    logr: true
+    zap: true

--- a/pkg/gcp/fake/mockserver.go
+++ b/pkg/gcp/fake/mockserver.go
@@ -82,7 +82,7 @@ func decodeOperationType(r *http.Request, index int) string {
 func handleCreate(w http.ResponseWriter, r *http.Request) {
 
 	if decodeOperationType(r, 2) == "invalid post" {
-		http.Error(w, fmt.Sprint("Invalid post zone"), http.StatusBadRequest)
+		http.Error(w, "Invalid post zone", http.StatusBadRequest)
 		return
 	}
 
@@ -103,18 +103,18 @@ func handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	Instances = append(Instances, instance)
-	json.NewEncoder(w).Encode(operation)
+	_ = json.NewEncoder(w).Encode(operation)
 }
 
 func handleList(w http.ResponseWriter, r *http.Request) {
 	//error mock handling for create/delete calls
 	if decodeOperationType(r, 3) == "invalid list" {
-		http.Error(w, fmt.Sprint("Invalid list zone"), http.StatusBadRequest)
+		http.Error(w, "Invalid list zone", http.StatusBadRequest)
 		return
 	}
 	//error mock handling for listMachines call
 	if decodeOperationType(r, 2) == "invalid list" {
-		http.Error(w, fmt.Sprint("Invalid list zone"), http.StatusBadRequest)
+		http.Error(w, "Invalid list zone", http.StatusBadRequest)
 		return
 	}
 
@@ -125,20 +125,20 @@ func handleList(w http.ResponseWriter, r *http.Request) {
 			OperationType: "insert",
 			Kind:          "compute#operation",
 		}
-		json.NewEncoder(w).Encode(operation)
+		_ = json.NewEncoder(w).Encode(operation)
 	} else { // this is the regular list call handling for VM
 
 		instances := compute.InstanceList{
 			Items: Instances,
 		}
-		json.NewEncoder(w).Encode(instances)
+		_ = json.NewEncoder(w).Encode(instances)
 
 	}
 }
 
 func handleDelete(w http.ResponseWriter, r *http.Request) {
 	if decodeOperationType(r, 3) == "invalid post" {
-		http.Error(w, fmt.Sprint("Invalid post zone"), http.StatusBadRequest)
+		http.Error(w, "Invalid post zone", http.StatusBadRequest)
 		return
 	}
 
@@ -151,5 +151,5 @@ func handleDelete(w http.ResponseWriter, r *http.Request) {
 		OperationType: "delete",
 		Kind:          "compute#operation",
 	}
-	json.NewEncoder(w).Encode(operation)
+	_ = json.NewEncoder(w).Encode(operation)
 }

--- a/pkg/gcp/integration/integration_test.go
+++ b/pkg/gcp/integration/integration_test.go
@@ -72,7 +72,7 @@ func TestPluginSPIImpl(t *testing.T) {
 		return
 	}
 
-	providerID, err = ms.DeleteMachineUtil(ctx, cfg.MachineName, providerID, cfg.ProviderSpec, cfg.Secrets)
+	_, err = ms.DeleteMachineUtil(ctx, cfg.MachineName, providerID, cfg.ProviderSpec, cfg.Secrets)
 	switch err.(type) {
 	case *errors.MachineNotFoundError:
 		// expected

--- a/pkg/gcp/machine_controller.go
+++ b/pkg/gcp/machine_controller.go
@@ -101,7 +101,7 @@ func (ms *MachinePlugin) CreateMachine(ctx context.Context, req *driver.CreateMa
 }
 
 // InitializeMachine handles VM initialization for GCP VM's. Currently, un-implemented.
-func (ms *MachinePlugin) InitializeMachine(ctx context.Context, _ *driver.InitializeMachineRequest) (*driver.InitializeMachineResponse, error) {
+func (ms *MachinePlugin) InitializeMachine(_ context.Context, _ *driver.InitializeMachineRequest) (*driver.InitializeMachineResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "GCP Provider does not yet implement InitializeMachine")
 }
 
@@ -252,7 +252,7 @@ func (ms *MachinePlugin) ListMachines(ctx context.Context, req *driver.ListMachi
 //
 // RESPONSE PARAMETERS (driver.GetVolumeIDsResponse)
 // VolumeIDs             repeated string     VolumeIDs is a repeated list of VolumeIDs.
-func (ms *MachinePlugin) GetVolumeIDs(ctx context.Context, req *driver.GetVolumeIDsRequest) (*driver.GetVolumeIDsResponse, error) {
+func (ms *MachinePlugin) GetVolumeIDs(_ context.Context, req *driver.GetVolumeIDsRequest) (*driver.GetVolumeIDsResponse, error) {
 	// Log messages to track start of request
 	klog.V(2).Infof("GetVolumeIDs request has been received")
 	klog.V(4).Infof("PVSpecList = %q", req.PVSpecs)

--- a/pkg/gcp/machine_controller_util.go
+++ b/pkg/gcp/machine_controller_util.go
@@ -35,7 +35,7 @@ const (
 )
 
 // CreateMachineUtil method is used to create a GCP machine
-func (ms *MachinePlugin) CreateMachineUtil(ctx context.Context, machineName string, providerSpec *api.GCPProviderSpec, secret *corev1.Secret) (string, error) {
+func (ms *MachinePlugin) CreateMachineUtil(_ context.Context, machineName string, providerSpec *api.GCPProviderSpec, secret *corev1.Secret) (string, error) {
 	ctx, computeService, err := ms.SPI.NewComputeService(secret)
 	if err != nil {
 		return "", err
@@ -98,7 +98,7 @@ func (ms *MachinePlugin) CreateMachineUtil(ctx context.Context, machineName stri
 	for _, nic := range providerSpec.NetworkInterfaces {
 		computeNIC := &compute.NetworkInterface{}
 
-		if nic.DisableExternalIP == false {
+		if !nic.DisableExternalIP {
 			// When DisableExternalIP is false, implies Attach an external IP to VM
 			computeNIC.AccessConfigs = []*compute.AccessConfig{{}}
 		}
@@ -188,7 +188,7 @@ func encodeMachineID(project, zone, name string) string {
 }
 
 // DeleteMachineUtil deletes a VM by name
-func (ms *MachinePlugin) DeleteMachineUtil(ctx context.Context, machineName string, _ string, providerSpec *api.GCPProviderSpec, secret *corev1.Secret) (string, error) {
+func (ms *MachinePlugin) DeleteMachineUtil(_ context.Context, machineName string, _ string, providerSpec *api.GCPProviderSpec, secret *corev1.Secret) (string, error) {
 	ctx, computeService, err := ms.SPI.NewComputeService(secret)
 	if err != nil {
 		return "", err
@@ -220,7 +220,7 @@ func (ms *MachinePlugin) DeleteMachineUtil(ctx context.Context, machineName stri
 }
 
 // GetMachineStatusUtil checks for existence of VM by name
-func (ms *MachinePlugin) GetMachineStatusUtil(ctx context.Context, machineName string, _ string, providerSpec *api.GCPProviderSpec, secret *corev1.Secret) (string, error) {
+func (ms *MachinePlugin) GetMachineStatusUtil(_ context.Context, machineName string, _ string, providerSpec *api.GCPProviderSpec, secret *corev1.Secret) (string, error) {
 	ctx, computeService, err := ms.SPI.NewComputeService(secret)
 	if err != nil {
 		return "", err
@@ -244,7 +244,7 @@ func (ms *MachinePlugin) GetMachineStatusUtil(ctx context.Context, machineName s
 }
 
 // ListMachinesUtil lists all VMs in the DC or folder
-func (ms *MachinePlugin) ListMachinesUtil(ctx context.Context, providerSpec *api.GCPProviderSpec, secret *corev1.Secret) (map[string]string, error) {
+func (ms *MachinePlugin) ListMachinesUtil(_ context.Context, providerSpec *api.GCPProviderSpec, secret *corev1.Secret) (map[string]string, error) {
 	ctx, computeService, err := ms.SPI.NewComputeService(secret)
 	if err != nil {
 		return nil, err

--- a/test/integration/provider/rti.go
+++ b/test/integration/provider/rti.go
@@ -6,9 +6,8 @@ import (
 	"log"
 
 	api "github.com/gardener/machine-controller-manager-provider-gcp/pkg/api/v1alpha1"
-	gcp "github.com/gardener/machine-controller-manager-provider-gcp/pkg/gcp"
-	providerDriver "github.com/gardener/machine-controller-manager-provider-gcp/pkg/gcp"
-	v1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/gardener/machine-controller-manager-provider-gcp/pkg/gcp"
+	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -53,7 +52,7 @@ func (r *ResourcesTrackerImpl) InitializeResourcesTracker(machineClass *v1alpha1
 		return err
 	}
 
-	project, err := providerDriver.ExtractProject(r.SecretData)
+	project, err := gcp.ExtractProject(r.SecretData)
 	if err != nil {
 		return err
 	}
@@ -78,7 +77,7 @@ func (r *ResourcesTrackerImpl) probeResources() ([]string, []string, []string, e
 		return nil, nil, nil, err
 	}
 
-	project, err := providerDriver.ExtractProject(r.SecretData)
+	project, err := gcp.ExtractProject(r.SecretData)
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR replaces the deprecated `golint` with `golangci-lint`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
golangci-lint will now be used as the linter instead of the older golint
```