### PR TITLE
[GEP-26] Support for GCP credentials configuration

### DIFF
--- a/pkg/api/v1alpha1/provider_spec.go
+++ b/pkg/api/v1alpha1/provider_spec.go
@@ -10,6 +10,8 @@ const (
 	// GCPAlternativeServiceAccountJSON is a constant for a key name of a secret containing the GCP credentials (service
 	// account json).
 	GCPAlternativeServiceAccountJSON = "serviceaccount.json"
+	// GCPCredentialsConfig is a constant for a key name of a secret containing the GCP credentials configuration.
+	GCPCredentialsConfig = "credentialsConfig"
 
 	// GCPDiskTypeScratch is the SCRATCH disk type
 	GCPDiskTypeScratch = "SCRATCH"

--- a/pkg/gcp/fake/mockclient.go
+++ b/pkg/gcp/fake/mockclient.go
@@ -6,7 +6,7 @@ package mock
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/http"
 
 	compute "google.golang.org/api/compute/v1"
@@ -22,13 +22,14 @@ type PluginSPIImpl struct {
 }
 
 // NewComputeService creates a compute service instance using the mock
-func (ms *PluginSPIImpl) NewComputeService(secrets *corev1.Secret) (context.Context, *compute.Service, error) {
+func (ms *PluginSPIImpl) NewComputeService(secret *corev1.Secret) (context.Context, *compute.Service, error) {
 	ctx := context.Background()
 
-	_, serviceAccountJSON := secrets.Data[api.GCPServiceAccountJSON]
-	_, serviceAccountJSONAlternative := secrets.Data[api.GCPAlternativeServiceAccountJSON]
-	if !serviceAccountJSON && !serviceAccountJSONAlternative {
-		return nil, nil, fmt.Errorf("Missing secrets to connect to compute service")
+	_, serviceAccountJSON := secret.Data[api.GCPServiceAccountJSON]
+	_, serviceAccountJSONAlternative := secret.Data[api.GCPAlternativeServiceAccountJSON]
+	_, credentialsConfig := secret.Data[api.GCPCredentialsConfig]
+	if !serviceAccountJSON && !serviceAccountJSONAlternative && !credentialsConfig {
+		return nil, nil, errors.New("Missing secrets to connect to compute service")
 	}
 
 	// create a compute service using a mockclient work

--- a/pkg/gcp/machine_controller_test.go
+++ b/pkg/gcp/machine_controller_test.go
@@ -16,7 +16,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	api "github.com/gardener/machine-controller-manager-provider-gcp/pkg/api/v1alpha1"
 	fake "github.com/gardener/machine-controller-manager-provider-gcp/pkg/gcp/fake"
 )
 
@@ -117,21 +116,21 @@ var _ = Describe("#MachineController", func() {
 	}
 
 	gcpProviderSecret := map[string][]byte{
-		"userData":                []byte("dummy-data"),
-		api.GCPServiceAccountJSON: []byte("{\"type\":\"service_account\",\"project_id\":\"sap-se-gcp-scp-k8s-dev\"}"),
+		"userData":           []byte("dummy-data"),
+		"serviceAccountJSON": []byte("{\"type\":\"service_account\",\"project_id\":\"sap-se-gcp-scp-k8s-dev\"}"),
 	}
 	gcpProviderSecretWithCredentialsConfig := map[string][]byte{
-		"userData":               []byte("dummy-data"),
-		api.GCPCredentialsConfig: []byte("{\"type\":\"service_account\",\"project_id\":\"sap-se-gcp-scp-k8s-dev\"}"),
+		"userData":          []byte("dummy-data"),
+		"credentialsConfig": []byte("{\"type\":\"service_account\",\"project_id\":\"sap-se-gcp-scp-k8s-dev\"}"),
 	}
 
 	gcpProviderSecretWithMisssingUserData := map[string][]byte{
 		// "userData":           []byte(""),
-		api.GCPServiceAccountJSON: []byte("{\"type\":\"service_account\",\"project_id\":\"sap-se-gcp-scp-k8s-dev\"}"),
+		"serviceAccountJSON": []byte("{\"type\":\"service_account\",\"project_id\":\"sap-se-gcp-scp-k8s-dev\"}"),
 	}
 	gcpProviderSecretWithoutProjectID := map[string][]byte{
-		"userData":                []byte("dummy-data"),
-		api.GCPServiceAccountJSON: []byte("{\"type\":\"service_account\",\"project_id\":10}"),
+		"userData":           []byte("dummy-data"),
+		"serviceAccountJSON": []byte("{\"type\":\"service_account\",\"project_id\":10}"),
 	}
 
 	var _ = BeforeEach(func() {
@@ -140,8 +139,6 @@ var _ = Describe("#MachineController", func() {
 	})
 
 	Describe("##CreateMachine", func() {
-		type setup struct {
-		}
 		type action struct {
 			machineRequest *driver.CreateMachineRequest
 		}
@@ -151,7 +148,6 @@ var _ = Describe("#MachineController", func() {
 			errMessage        string
 		}
 		type data struct {
-			setup  setup
 			action action
 			expect expect
 		}
@@ -170,7 +166,7 @@ var _ = Describe("#MachineController", func() {
 				}
 			},
 
-			Entry("Creata a simple machine", &data{
+			Entry("Create a simple machine", &data{
 				action: action{
 					machineRequest: &driver.CreateMachineRequest{
 						Machine:      newMachine("dummy-machine"),
@@ -186,7 +182,7 @@ var _ = Describe("#MachineController", func() {
 					errToHaveOccurred: false,
 				},
 			}),
-			Entry("Creata a simple machine from secret with credentialsConfig", &data{
+			Entry("Create a simple machine from secret with credentialsConfig", &data{
 				action: action{
 					machineRequest: &driver.CreateMachineRequest{
 						Machine:      newMachine("dummy-machine"),
@@ -218,7 +214,7 @@ var _ = Describe("#MachineController", func() {
 					errToHaveOccurred: false,
 				},
 			}),
-			Entry("Creata a simple machine with unsupported provider in MachineClass", &data{
+			Entry("Create a simple machine with unsupported provider in MachineClass", &data{
 				action: action{
 					machineRequest: &driver.CreateMachineRequest{
 						Machine:      newMachine("dummy-machine"),
@@ -352,8 +348,6 @@ var _ = Describe("#MachineController", func() {
 		)
 	})
 	Describe("##DeleteMachine", func() {
-		type setup struct {
-		}
 		type action struct {
 			machineRequest *driver.DeleteMachineRequest
 		}
@@ -363,7 +357,6 @@ var _ = Describe("#MachineController", func() {
 			errMessage        string
 		}
 		type data struct {
-			setup  setup
 			action action
 			expect expect
 		}
@@ -439,8 +432,6 @@ var _ = Describe("#MachineController", func() {
 		)
 	})
 	Describe("##ListMachines", func() {
-		type setup struct {
-		}
 		type action struct {
 			createMachine bool
 			createRequest *driver.CreateMachineRequest
@@ -448,7 +439,6 @@ var _ = Describe("#MachineController", func() {
 		}
 		type expect struct {
 			createResponse          *driver.CreateMachineResponse
-			listResponse            *driver.ListMachinesResponse
 			errToHaveOccurred       bool
 			listErrToHaveOccurred   bool
 			createErrToHaveOccurred bool
@@ -456,7 +446,6 @@ var _ = Describe("#MachineController", func() {
 			errMessage              string
 		}
 		type data struct {
-			setup  setup
 			action action
 			expect expect
 		}
@@ -562,8 +551,6 @@ var _ = Describe("#MachineController", func() {
 
 	})
 	Describe("##GetMachineStatus", func() {
-		type setup struct {
-		}
 		type action struct {
 			createMachine    bool
 			createRequest    *driver.CreateMachineRequest
@@ -579,7 +566,6 @@ var _ = Describe("#MachineController", func() {
 			machineCount               int
 		}
 		type data struct {
-			setup  setup
 			action action
 			expect expect
 		}
@@ -695,8 +681,6 @@ var _ = Describe("#MachineController", func() {
 		)
 	})
 	Describe("##GetVolumeIDs", func() {
-		type setup struct {
-		}
 		type action struct {
 			machineRequest *driver.GetVolumeIDsRequest
 		}
@@ -706,7 +690,6 @@ var _ = Describe("#MachineController", func() {
 			errMessage        string
 		}
 		type data struct {
-			setup  setup
 			action action
 			expect expect
 		}
@@ -795,14 +778,6 @@ var _ = Describe("#MachineController", func() {
 		)
 	})
 })
-
-func getBoolPtr(b bool) *bool {
-	return &b
-}
-
-func getStringPtr(s string) *string {
-	return &s
-}
 
 func newMachine(name string) *v1alpha1.Machine {
 	return &v1alpha1.Machine{

--- a/pkg/gcp/machine_controller_test.go
+++ b/pkg/gcp/machine_controller_test.go
@@ -120,6 +120,10 @@ var _ = Describe("#MachineController", func() {
 		"userData":                []byte("dummy-data"),
 		api.GCPServiceAccountJSON: []byte("{\"type\":\"service_account\",\"project_id\":\"sap-se-gcp-scp-k8s-dev\"}"),
 	}
+	gcpProviderSecretWithCredentialsConfig := map[string][]byte{
+		"userData":               []byte("dummy-data"),
+		api.GCPCredentialsConfig: []byte("{\"type\":\"service_account\",\"project_id\":\"sap-se-gcp-scp-k8s-dev\"}"),
+	}
 
 	gcpProviderSecretWithMisssingUserData := map[string][]byte{
 		// "userData":           []byte(""),
@@ -172,6 +176,22 @@ var _ = Describe("#MachineController", func() {
 						Machine:      newMachine("dummy-machine"),
 						MachineClass: newGCPMachineClass(gcpProviderSpec, ""),
 						Secret:       newSecret(gcpProviderSecret),
+					},
+				},
+				expect: expect{
+					machineResponse: &driver.CreateMachineResponse{
+						ProviderID: "gce:///sap-se-gcp-scp-k8s-dev/europe-dummy/dummy-machine",
+						NodeName:   "dummy-machine",
+					},
+					errToHaveOccurred: false,
+				},
+			}),
+			Entry("Creata a simple machine from secret with credentialsConfig", &data{
+				action: action{
+					machineRequest: &driver.CreateMachineRequest{
+						Machine:      newMachine("dummy-machine"),
+						MachineClass: newGCPMachineClass(gcpProviderSpec, ""),
+						Secret:       newSecret(gcpProviderSecretWithCredentialsConfig),
 					},
 				},
 				expect: expect{

--- a/pkg/gcp/machine_controller_test.go
+++ b/pkg/gcp/machine_controller_test.go
@@ -32,7 +32,7 @@ const (
 	// ListFailAtJSONUnmarshalling is the error message returned when an malformed JSON is sent to the plugin by the caller
 	ListFailAtJSONUnmarshalling string = "machine codes error: code = [Internal] message = [List machines failed on decodeProviderSpec: machine codes error: code = [Internal] message = [unexpected end of JSON input]]"
 	// FailAtNoSecretsPassed is the error message returned when no secrets are passed to the the plugin by the caller
-	FailAtNoSecretsPassed string = "machine codes error: code = [Internal] message = [Create machine \"dummy-machine\" failed on validateSecret: machine codes error: code = [Internal] message = [error while validating Secret [secret serviceAccountJSON or serviceaccount.json is required field secret userData is required field]]]"
+	FailAtNoSecretsPassed string = "machine codes error: code = [Internal] message = [Create machine \"dummy-machine\" failed on validateSecret: machine codes error: code = [Internal] message = [error while validating Secret [secret serviceAccountJSON, serviceaccount.json or credentialsConfig is required field secret userData is required field]]]"
 	// FailAtSecretsWithNoUserData is the error message returned when secrets map has no userdata provided by the caller
 	FailAtSecretsWithNoUserData string = "machine codes error: code = [Internal] message = [Create machine \"dummy-machine\" failed on validateSecret: machine codes error: code = [Internal] message = [error while validating Secret [secret userData is required field]]]"
 	// FailAtInvalidProjectID is the error returned when an invalid project id value is provided by the caller

--- a/pkg/gcp/machine_controller_util.go
+++ b/pkg/gcp/machine_controller_util.go
@@ -379,12 +379,12 @@ func prepareErrorf(err error, format string, args ...interface{}) error {
 
 // ExtractProject returns the name of the project which is extracted from the secret
 func ExtractProject(credentialsData map[string][]byte) (string, error) {
-	serviceAccountJSON := extractCredentialsFromData(credentialsData, api.GCPServiceAccountJSON, api.GCPAlternativeServiceAccountJSON, api.GCPCredentialsConfig)
+	credentialsConfigJSON := extractCredentialsFromData(credentialsData, api.GCPServiceAccountJSON, api.GCPAlternativeServiceAccountJSON, api.GCPCredentialsConfig)
 
 	var j struct {
 		Project string `json:"project_id"`
 	}
-	if err := json.Unmarshal([]byte(serviceAccountJSON), &j); err != nil {
+	if err := json.Unmarshal([]byte(credentialsConfigJSON), &j); err != nil {
 		return "Error", err
 	}
 

--- a/pkg/gcp/machine_controller_util.go
+++ b/pkg/gcp/machine_controller_util.go
@@ -379,7 +379,7 @@ func prepareErrorf(err error, format string, args ...interface{}) error {
 
 // ExtractProject returns the name of the project which is extracted from the secret
 func ExtractProject(credentialsData map[string][]byte) (string, error) {
-	serviceAccountJSON := extractCredentialsFromData(credentialsData, api.GCPServiceAccountJSON, api.GCPAlternativeServiceAccountJSON)
+	serviceAccountJSON := extractCredentialsFromData(credentialsData, api.GCPServiceAccountJSON, api.GCPAlternativeServiceAccountJSON, api.GCPCredentialsConfig)
 
 	var j struct {
 		Project string `json:"project_id"`
@@ -387,7 +387,12 @@ func ExtractProject(credentialsData map[string][]byte) (string, error) {
 	if err := json.Unmarshal([]byte(serviceAccountJSON), &j); err != nil {
 		return "Error", err
 	}
-	return j.Project, nil
+
+	if j.Project != "" {
+		return j.Project, nil
+	}
+
+	return string(credentialsData["projectID"]), nil
 }
 
 // WaitUntilOperationCompleted waits for the specified operation to be completed and returns true if it does else returns false

--- a/pkg/gcp/validation/validation.go
+++ b/pkg/gcp/validation/validation.go
@@ -56,10 +56,11 @@ func ValidateSecret(secret *corev1.Secret) []error {
 	} else {
 		_, serviceAccountJSONExists := secret.Data[api.GCPServiceAccountJSON]
 		_, serviceAccountJSONAlternativeExists := secret.Data[api.GCPAlternativeServiceAccountJSON]
+		_, credentialsConfigExists := secret.Data[api.GCPCredentialsConfig]
 		_, userDataExists := secret.Data["userData"]
 
-		if !serviceAccountJSONExists && !serviceAccountJSONAlternativeExists {
-			allErrs = append(allErrs, fmt.Errorf("secret %s or %s is required field", api.GCPServiceAccountJSON, api.GCPAlternativeServiceAccountJSON))
+		if !serviceAccountJSONExists && !serviceAccountJSONAlternativeExists && !credentialsConfigExists {
+			allErrs = append(allErrs, fmt.Errorf("secret %s, %s or %s is required field", api.GCPServiceAccountJSON, api.GCPAlternativeServiceAccountJSON, api.GCPCredentialsConfig))
 		}
 		if !userDataExists {
 			allErrs = append(allErrs, fmt.Errorf("secret userData is required field"))


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables support for credentials configuration different from a file containing service account info. This enables support for [workload identity federation](https://cloud.google.com/iam/docs/workload-identity-federation-with-kubernetes#go).

Work in progress
/hold

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement developer
MCM can now retrieve the project ID from a "projectID" data key, allowing support for credential configurations that do not directly contain the project ID. One such case is a [workload identity credential configuration](https://cloud.google.com/iam/docs/workload-download-cred-and-grant-access).
```