### PR TITLE
Enable submitting shielded instance configs for VMs

### DIFF
--- a/docs/docs/provider-spec.md
+++ b/docs/docs/provider-spec.md
@@ -295,6 +295,22 @@ string
 <p>Zone: in which instance is to be deployed</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>shieldedInstanceConfiguration</code>
+</td>
+<td>
+<em>
+<a href="#settings.gardener.cloud/v1alpha1.ShieldedInstanceConfiguration">
+ShieldedInstanceConfiguration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ShieldedInstanceConfiguration is a shielded instance configuration</p>
+</td>
+</tr>
 </tbody>
 </table>
 <br>
@@ -863,6 +879,70 @@ string
 <td>
 <p>Scopes: The list of scopes to be made available for this service
 account.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<br>
+<h3 id="settings.gardener.cloud/v1alpha1.ShieldedInstanceConfiguration">
+<b>ShieldedInstanceConfiguration</b>
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#settings.gardener.cloud/v1alpha1.GCPProviderSpec">GCPProviderSpec</a>)
+</p>
+<p>
+<p>ShieldedInstanceConfiguration describes the shielded instance configuration for GCE VMs</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>integrityMonitoring</code>
+</td>
+<td>
+<em>
+*bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>IntegrityMonitoring enables integrity monitoring</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>secureBoot</code>
+</td>
+<td>
+<em>
+*bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecureBoot enables secure boot</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>vtpm</code>
+</td>
+<td>
+<em>
+*bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Vtpm enables vTPM</p>
 </td>
 </tr>
 </tbody>

--- a/kubernetes/machine-class.yaml
+++ b/kubernetes/machine-class.yaml
@@ -49,6 +49,10 @@ providerSpec:
     #- key2 # A set of additional tags attached to a machine (optional)
   region: europe-west1 # Region to attach the instanc
   zone: europe-west1-b
+# shieldedInstanceConfiguration: # An optional field to configure a shielded instance
+#   integrityMonitoring: false # Integrity monitoring is enabled by default for UEFI_COMPATIBLE machine images and can be disabled with this setting
+#   vtpm: false # A virtual Trusted Platform Module (vTPM) is enabled by default for UEFI_COMPATIBLE machine images and can be disabled with this setting
+#   secureBoot: true # This enables secureboot for the shielded instance
 secretRef: # If required
   name: test-secret
   namespace: default # Namespace where the controller would watch

--- a/pkg/api/v1alpha1/provider_spec.go
+++ b/pkg/api/v1alpha1/provider_spec.go
@@ -115,6 +115,25 @@ type GCPProviderSpec struct {
 
 	// Zone: in which instance is to be deployed
 	Zone string `json:"zone"`
+
+	// ShieldedInstanceConfiguration is a shielded instance configuration
+	// +optional
+	ShieldedInstanceConfiguration *ShieldedInstanceConfiguration `json:"shieldedInstanceConfiguration,omitempty"`
+}
+
+// ShieldedInstanceConfiguration describes the shielded instance configuration for GCE VMs
+type ShieldedInstanceConfiguration struct {
+	// IntegrityMonitoring enables integrity monitoring
+	// +optional
+	IntegrityMonitoring *bool `json:"integrityMonitoring,omitempty"`
+
+	// SecureBoot enables secure boot
+	// +optional
+	SecureBoot *bool `json:"secureBoot,omitempty"`
+
+	// Vtpm enables vTPM
+	// +optional
+	Vtpm *bool `json:"vtpm,omitempty"`
 }
 
 // GCPDisk describes disks for GCP.

--- a/pkg/gcp/machine_controller_util.go
+++ b/pkg/gcp/machine_controller_util.go
@@ -75,6 +75,19 @@ func (ms *MachinePlugin) CreateMachineUtil(_ context.Context, machineName string
 		}
 	}
 
+	if providerSpec.ShieldedInstanceConfiguration != nil {
+		instance.ShieldedInstanceConfig = &compute.ShieldedInstanceConfig{}
+		if providerSpec.ShieldedInstanceConfiguration.IntegrityMonitoring != nil {
+			instance.ShieldedInstanceConfig.EnableIntegrityMonitoring = *providerSpec.ShieldedInstanceConfiguration.IntegrityMonitoring
+		}
+		if providerSpec.ShieldedInstanceConfiguration.SecureBoot != nil {
+			instance.ShieldedInstanceConfig.EnableSecureBoot = *providerSpec.ShieldedInstanceConfiguration.SecureBoot
+		}
+		if providerSpec.ShieldedInstanceConfiguration.Vtpm != nil {
+			instance.ShieldedInstanceConfig.EnableVtpm = *providerSpec.ShieldedInstanceConfiguration.Vtpm
+		}
+	}
+
 	if providerSpec.Description != nil {
 		instance.Description = *providerSpec.Description
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support to provide a `shieldedInstanceConfig` for GCE VMs to be able to control the Shielded Instance Settings `vTPM`, `IntegrityMonitoring ` (both enable by default if a GCE VM is booted from an image that is `UEFI_COMPATIBLE`) and `secureBoot`(which needs to be explicitly enabled).

In order to allow be able to support secure boot enabled operaing systems on GCP, MCM provider GCP should be able to provide a `shieldedInstanceConfig` to GCP if the machineClass asks for it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
MCM provider GCP is able to provide the values for a `shieldedInstanceConfiguration` from a machineClass to the GCP API.
```