### PR TITLE
Enable StoragePool

### DIFF
--- a/docs/docs/provider-spec.md
+++ b/docs/docs/provider-spec.md
@@ -527,10 +527,11 @@ will not write any &ldquo;empty&rdquo; values to the request</p>
 </td>
 <td>
 <em>
-string
+*string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>StoragePool in which the new disk is created.
 You can provide this as a partial or full URL to the resource. For example
 <a href="https://www.googleapis.com/compute/v1/projects/project/zones/zone">https://www.googleapis.com/compute/v1/projects/project/zones/zone</a></p>

--- a/docs/docs/provider-spec.md
+++ b/docs/docs/provider-spec.md
@@ -521,6 +521,21 @@ the value zero will be omitted from the request because GCP client
 will not write any &ldquo;empty&rdquo; values to the request</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>storagePool</code>
+</td>
+<td>
+<em>
+string
+</em>
+</td>
+<td>
+<p>StoragePool in which the new disk is created.
+You can provide this as a partial or full URL to the resource. For example
+<a href="https://www.googleapis.com/compute/v1/projects/project/zones/zone">https://www.googleapis.com/compute/v1/projects/project/zones/zone</a></p>
+</td>
+</tr>
 </tbody>
 </table>
 <br>

--- a/kubernetes/machine-class.yaml
+++ b/kubernetes/machine-class.yaml
@@ -19,7 +19,7 @@ providerSpec:
 #       kmsKeyServiceAccount: "id@project.iam.gserviceaccount.com" # email of service account (optional)
 #     provisionedIops: 3000 # IOPS that the disk can handle (optional)
 #     provisionedThroughput: 140 # throughput unit in MB per sec (optional)
-#     storagePool: zones/zone/storagePools/storagePool # StoragePool where the new disk is created (optional)
+#     storagePool: projects/<projectName>/zones/<zoneName>/storagePools/<storagePoolName> # StoragePool where the new disk is created (optional). Can be passed as a partial or full URL to the resource
       labels:
         name: test-mc # Label assigned to the disk
   labels:

--- a/kubernetes/machine-class.yaml
+++ b/kubernetes/machine-class.yaml
@@ -19,6 +19,7 @@ providerSpec:
 #       kmsKeyServiceAccount: "id@project.iam.gserviceaccount.com" # email of service account (optional)
 #     provisionedIops: 3000 # IOPS that the disk can handle (optional)
 #     provisionedThroughput: 140 # throughput unit in MB per sec (optional)
+#     storagePool: zones/zone/storagePools/storagePool # StoragePool where the new disk is created (optional)
       labels:
         name: test-mc # Label assigned to the disk
   labels:

--- a/pkg/api/v1alpha1/provider_spec.go
+++ b/pkg/api/v1alpha1/provider_spec.go
@@ -240,7 +240,8 @@ type GCPDisk struct {
 	// StoragePool in which the new disk is created.
 	// You can provide this as a partial or full URL to the resource. For example
 	// https://www.googleapis.com/compute/v1/projects/project/zones/zone
-	StoragePool string `json:"storagePool,omitempty"`
+	// +optional
+	StoragePool *string `json:"storagePool,omitempty"`
 }
 
 // GCPDiskEncryption holds references to encryption data

--- a/pkg/api/v1alpha1/provider_spec.go
+++ b/pkg/api/v1alpha1/provider_spec.go
@@ -236,6 +236,11 @@ type GCPDisk struct {
 	// the value zero will be omitted from the request because GCP client
 	// will not write any "empty" values to the request
 	ProvisionedThroughput int64 `json:"provisionedThroughput,omitempty"`
+
+	// StoragePool in which the new disk is created.
+	// You can provide this as a partial or full URL to the resource. For example
+	// https://www.googleapis.com/compute/v1/projects/project/zones/zone
+	StoragePool string `json:"storagePool,omitempty"`
 }
 
 // GCPDiskEncryption holds references to encryption data

--- a/pkg/gcp/machine_controller_util.go
+++ b/pkg/gcp/machine_controller_util.go
@@ -184,6 +184,7 @@ func createAttachedDisks(disks []*api.GCPDisk, zone, machineName string) []*comp
 					SourceImage:           disk.Image,
 					ProvisionedIops:       disk.ProvisionedIops,
 					ProvisionedThroughput: disk.ProvisionedThroughput,
+					StoragePool:           disk.StoragePool,
 				},
 			}
 		}

--- a/pkg/gcp/machine_controller_util.go
+++ b/pkg/gcp/machine_controller_util.go
@@ -184,7 +184,7 @@ func createAttachedDisks(disks []*api.GCPDisk, zone, machineName string) []*comp
 					SourceImage:           disk.Image,
 					ProvisionedIops:       disk.ProvisionedIops,
 					ProvisionedThroughput: disk.ProvisionedThroughput,
-					StoragePool:           disk.StoragePool,
+					StoragePool:           ptr.Deref(disk.StoragePool, ""),
 				},
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables extensions to pass values for the storagePool field in the provider spec.
See also https://cloud.google.com/backup-disaster-recovery/docs/concepts/storage-pools.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
Add storagePool field to provider spec
```