### PR TITLE
Add option to configure enable nested virtualization

### DIFF
--- a/docs/docs/provider-spec.md
+++ b/docs/docs/provider-spec.md
@@ -311,6 +311,62 @@ ShieldedInstanceConfiguration
 <p>ShieldedInstanceConfiguration is a shielded instance configuration</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>advancedMachineFeatures</code>
+</td>
+<td>
+<em>
+<a href="#settings.gardener.cloud/v1alpha1.AdvancedMachineFeatures">
+AdvancedMachineFeatures
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AdvancedMachineFeatures specifies advanced options like BIOS or OS configuration.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<br>
+<h3 id="settings.gardener.cloud/v1alpha1.AdvancedMachineFeatures">
+<b>AdvancedMachineFeatures</b>
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#settings.gardener.cloud/v1alpha1.GCPProviderSpec">GCPProviderSpec</a>)
+</p>
+<p>
+<p>AdvancedMachineFeatures: Specifies options for controlling advanced machine
+features. Options that would traditionally be configured in a BIOS belong
+here. Features that require operating system support may have corresponding
+entries in the GuestOsFeatures of an Image (e.g., whether or not the OS in
+the Image supports nested virtualization being enabled or disabled).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>enableNestedVirtualization</code>
+</td>
+<td>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>EnableNestedVirtualization: Whether to enable nested virtualization or not
+(default is false).</p>
+</td>
+</tr>
 </tbody>
 </table>
 <br>

--- a/pkg/api/v1alpha1/provider_spec.go
+++ b/pkg/api/v1alpha1/provider_spec.go
@@ -119,6 +119,10 @@ type GCPProviderSpec struct {
 	// ShieldedInstanceConfiguration is a shielded instance configuration
 	// +optional
 	ShieldedInstanceConfiguration *ShieldedInstanceConfiguration `json:"shieldedInstanceConfiguration,omitempty"`
+
+	// AdvancedMachineFeatures specifies advanced options like BIOS or OS configuration.
+	// +optional
+	AdvancedMachineFeatures *AdvancedMachineFeatures `json:"advancedMachineFeatures,omitempty"`
 }
 
 // ShieldedInstanceConfiguration describes the shielded instance configuration for GCE VMs
@@ -134,6 +138,17 @@ type ShieldedInstanceConfiguration struct {
 	// Vtpm enables vTPM
 	// +optional
 	Vtpm *bool `json:"vtpm,omitempty"`
+}
+
+// AdvancedMachineFeatures specifies options for controlling advanced machine
+// features. Options that would traditionally be configured in a BIOS belong
+// here. Features that require operating system support may have corresponding
+// entries in the GuestOsFeatures of an Image (e.g., whether or not the OS in
+// the Image supports nested virtualization being enabled or disabled).
+type AdvancedMachineFeatures struct {
+	// EnableNestedVirtualization: Whether to enable nested virtualization or not
+	// (default is false).
+	EnableNestedVirtualization bool `json:"enableNestedVirtualization,omitempty"`
 }
 
 // GCPDisk describes disks for GCP.

--- a/pkg/gcp/machine_controller_test.go
+++ b/pkg/gcp/machine_controller_test.go
@@ -80,6 +80,7 @@ var _ = Describe("#MachineController", func() {
 	gcpProviderSpecInvalidListZone := []byte("{\"canIpForward\":true,\"deletionProtection\":false,\"description\":\"Machine created to test out-of-tree gcp mcm driver.\",\"disks\":[{\"autoDelete\":true,\"boot\":true,\"sizeGb\":50,\"type\":\"pd-standard\",\"image\":\"projects/coreos-cloud/global/images/coreos-stable-2135-6-0-v20190801\",\"labels\":{\"name\":\"test-mc-gcp\"}}],\"labels\":{\"name\":\"test-mc-gcp\"},\"machineType\":\"n1-standard-2\",\"metadata\":[{\"key\":\"gcp\",\"value\":\"my-value\"}],\"networkInterfaces\":[{\"network\":\"dummyShoot\",\"subnetwork\":\"dummyShoot\"}],\"scheduling\":{\"automaticRestart\":true,\"onHostMaintenance\":\"MIGRATE\",\"preemptible\":false},\"secretRef\":{\"name\":\"dummySecret\",\"namespace\":\"dummy\"},\"serviceAccounts\":[{\"email\":\"mcmDummy@dummy.com\",\"scopes\":[\"https://www.googleapis.com/auth/compute\"]}],\"tags\":[\"kubernetes-io-cluster-dummy-machine\",\"kubernetes-io-role-mcm\",\"dummy-machine\"],\"region\":\"europe-dummy\",\"zone\":\"invalid list\"}")
 	gcpProviderSpecInvalidKmsKeyServiceAccount := []byte("{\"canIpForward\":true,\"deletionProtection\":false,\"description\":\"Machine created to test out-of-tree gcp mcm driver.\",\"disks\":[{\"autoDelete\":true,\"boot\":true,\"sizeGb\":50,\"type\":\"pd-standard\",\"image\":\"projects/coreos-cloud/global/images/coreos-stable-2135-6-0-v20190801\", \"encryption\": { \"kmsKeyName\": \"bingo\", \"kmsKeyServiceAccount\": \"  \"}, \"labels\":{\"name\":\"test-mc-gcp\"}}], \"labels\":{\"name\":\"test-mc-gcp\"},\"machineType\":\"n1-standard-2\",\"metadata\":[{\"key\":\"gcp\",\"value\":\"my-value\"}],\"networkInterfaces\":[{\"network\":\"dummyShoot\",\"subnetwork\":\"dummyShoot\"}],\"scheduling\":{\"automaticRestart\":true,\"onHostMaintenance\":\"MIGRATE\",\"preemptible\":false},\"secretRef\":{\"name\":\"dummySecret\",\"namespace\":\"dummy\"},\"serviceAccounts\":[{\"email\":\"mcmDummy@dummy.com\",\"scopes\":[\"https://www.googleapis.com/auth/compute\"]}],\"tags\":[\"kubernetes-io-cluster-dummy-machine\",\"kubernetes-io-role-mcm\",\"dummy-machine\"],\"region\":\"europe-dummy\",\"zone\":\"invalid list\"}")
 	gcpProviderSpecNoKmsKeyName := []byte("{\"canIpForward\":true,\"deletionProtection\":false,\"description\":\"Machine created to test out-of-tree gcp mcm driver.\",\"disks\":[{\"autoDelete\":true,\"boot\":true,\"sizeGb\":50,\"type\":\"pd-standard\",\"image\":\"projects/coreos-cloud/global/images/coreos-stable-2135-6-0-v20190801\", \"encryption\": { \"kmsKeyServiceAccount\": \"tringo\" }, \"labels\":{\"name\":\"test-mc-gcp\"}}], \"labels\":{\"name\":\"test-mc-gcp\"},\"machineType\":\"n1-standard-2\",\"metadata\":[{\"key\":\"gcp\",\"value\":\"my-value\"}],\"networkInterfaces\":[{\"network\":\"dummyShoot\",\"subnetwork\":\"dummyShoot\"}],\"scheduling\":{\"automaticRestart\":true,\"onHostMaintenance\":\"MIGRATE\",\"preemptible\":false},\"secretRef\":{\"name\":\"dummySecret\",\"namespace\":\"dummy\"},\"serviceAccounts\":[{\"email\":\"mcmDummy@dummy.com\",\"scopes\":[\"https://www.googleapis.com/auth/compute\"]}],\"tags\":[\"kubernetes-io-cluster-dummy-machine\",\"kubernetes-io-role-mcm\",\"dummy-machine\"],\"region\":\"europe-dummy\",\"zone\":\"invalid list\"}")
+	gcpProviderSpecAdvancedMachineFeatures := []byte("{\"canIpForward\":true,\"deletionProtection\":false,\"description\":\"Machine created to test out-of-tree gcp mcm driver.\",\"disks\":[{\"autoDelete\":true,\"boot\":true,\"sizeGb\":50,\"type\":\"pd-standard\",\"image\":\"projects/coreos-cloud/global/images/coreos-stable-2135-6-0-v20190801\",\"labels\":{\"name\":\"test-mc-gcp\"}}],\"labels\":{\"name\":\"test-mc-gcp\"},\"machineType\":\"n1-standard-2\",\"metadata\":[{\"key\":\"gcp\",\"value\":\"my-value\"}],\"networkInterfaces\":[{\"network\":\"dummyShoot\",\"subnetwork\":\"dummyShoot\"}],\"scheduling\":{\"automaticRestart\":true,\"onHostMaintenance\":\"MIGRATE\",\"preemptible\":false},\"secretRef\":{\"name\":\"dummySecret\",\"namespace\":\"dummy\"},\"serviceAccounts\":[{\"email\":\"mcmDummy@dummy.com\",\"scopes\":[\"https://www.googleapis.com/auth/compute\"]}],\"tags\":[\"kubernetes-io-cluster-dummy-machine\",\"kubernetes-io-role-mcm\",\"dummy-machine\"],\"region\":\"europe-dummy\",\"zone\":\"europe-dummy\",\"advancedMachineFeatures\":{\"enableNestedVirtualization\":true}}")
 
 	gcpPVSpecIntree := &corev1.PersistentVolumeSpec{
 		PersistentVolumeSource: corev1.PersistentVolumeSource{
@@ -188,6 +189,22 @@ var _ = Describe("#MachineController", func() {
 						Machine:      newMachine("dummy-machine"),
 						MachineClass: newGCPMachineClass(gcpProviderSpec, ""),
 						Secret:       newSecret(gcpProviderSecretWithCredentialsConfig),
+					},
+				},
+				expect: expect{
+					machineResponse: &driver.CreateMachineResponse{
+						ProviderID: "gce:///sap-se-gcp-scp-k8s-dev/europe-dummy/dummy-machine",
+						NodeName:   "dummy-machine",
+					},
+					errToHaveOccurred: false,
+				},
+			}),
+			Entry("Create a simple machine with advanced machine features", &data{
+				action: action{
+					machineRequest: &driver.CreateMachineRequest{
+						Machine:      newMachine("dummy-machine"),
+						MachineClass: newGCPMachineClass(gcpProviderSpecAdvancedMachineFeatures, ""),
+						Secret:       newSecret(gcpProviderSecret),
 					},
 				},
 				expect: expect{

--- a/pkg/gcp/machine_controller_util.go
+++ b/pkg/gcp/machine_controller_util.go
@@ -96,6 +96,12 @@ func (ms *MachinePlugin) CreateMachineUtil(_ context.Context, machineName string
 		}
 	}
 
+	if providerSpec.AdvancedMachineFeatures != nil {
+		instance.AdvancedMachineFeatures = &compute.AdvancedMachineFeatures{
+			EnableNestedVirtualization: providerSpec.AdvancedMachineFeatures.EnableNestedVirtualization,
+		}
+	}
+
 	if providerSpec.Description != nil {
 		instance.Description = *providerSpec.Description
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a configuration option `advancedMachineFeatures.enableNestedVirtualization` to enable nodes to be provisioned with nested virtualization.

the struct follows the same structure as the instance type https://pkg.go.dev/google.golang.org/api/compute/v1#AdvancedMachineFeatures .
Currently only the nested virtualization option is exposed but other options can be exposed in the future.

This feature is useful if people want to run KubeVirt oder other virtualization frameworks on google vms

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
It is now possible to provision node with nested virtualization.
```