### PR TITLE
Ensure mcm dependency is present in mod cache before running any make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+ENSURE_MCM_MOD := $(shell go mod download github.com/gardener/machine-controller-manager)
 MCM_DIR   	:= $(shell go list -m -f "{{.Dir}}" github.com/gardener/machine-controller-manager)
 TOOLS_DIR := hack/tools
 include $(MCM_DIR)/hack/tools.mk


### PR DESCRIPTION
**What this PR does / why we need it**:
There was an issue where some make targets would fail if MCM was not present in the mod cache. This caused these targets to fail.
This PR ensures that MCM is present in the mod cache before any make targets are run.
In case it is not present in the cache, it will be downloaded along with other dependencies required by it

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Fix an issue that caused make targets to fail by ensuring MCM is present in the mod cache
```