### PR TITLE
fix: typo (succesfully -> successfully) in termination log

### DIFF
--- a/pkg/gcp/machine_controller.go
+++ b/pkg/gcp/machine_controller.go
@@ -154,7 +154,7 @@ func (ms *MachinePlugin) DeleteMachine(ctx context.Context, req *driver.DeleteMa
 		return nil, prepareErrorf(err, "Delete machine %q failed", req.Machine.Name)
 	}
 
-	klog.V(2).Infof("VM %q for Machine %q was terminated succesfully", providerID, req.Machine.Name)
+	klog.V(2).Infof("VM %q for Machine %q was terminated successfully", providerID, req.Machine.Name)
 
 	return &driver.DeleteMachineResponse{}, nil
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Fixes 'succesfully' -> 'successfully' typo in termination log (pkg/gcp/machine_controller.go).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
String/comment-only change, no functional impact.

**Release note**:
```other operator
NONE
```
