### PR TITLE
fix: correct typos in termination log and integration test log

### DIFF
--- a/pkg/gcp/machine_controller.go
+++ b/pkg/gcp/machine_controller.go
@@ -154,7 +154,7 @@ func (ms *MachinePlugin) DeleteMachine(ctx context.Context, req *driver.DeleteMa
 		return nil, prepareErrorf(err, "Delete machine %q failed", req.Machine.Name)
 	}
 
-	klog.V(2).Infof("VM %q for Machine %q was terminated succesfully", providerID, req.Machine.Name)
+	klog.V(2).Infof("VM %q for Machine %q was terminated successfully", providerID, req.Machine.Name)
 
 	return &driver.DeleteMachineResponse{}, nil
 }

--- a/test/integration/provider/rti.go
+++ b/test/integration/provider/rti.go
@@ -88,7 +88,7 @@ func (r *ResourcesTrackerImpl) probeResources() ([]string, []string, []string, e
 
 	err = json.Unmarshal([]byte(r.MachineClass.ProviderSpec.Raw), &providerSpec)
 	if err != nil {
-		log.Printf("Error occured while performing unmarshal %s", err.Error())
+		log.Printf("Error occurred while performing unmarshal %s", err.Error())
 		return nil, nil, nil, err
 	}
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Fixes 'occured' -> 'occurred' typo in integration test log message (test/integration/provider/rti.go).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
String/comment-only change, no functional impact.

**Release note**:
```other operator
NONE
```
